### PR TITLE
Fix required param following optional param error in PHP 8

### DIFF
--- a/src/modules/db/classes/db_wherebase.php
+++ b/src/modules/db/classes/db_wherebase.php
@@ -11,7 +11,7 @@ class Db_WhereBase extends Db_Base
         $this->where = array();
     }
 
-    protected function _where($operator = 'AND', $cond)
+    protected function _where($operator, $cond)
     {
         if (is_null($cond)) {
             return $this;


### PR DESCRIPTION
Fixes

> Fatal error: Uncaught PHP Error: Required parameter $cond follows optional parameter $operator

In PHP 8.0+