### PR TITLE
Fix exception from boolean result

### DIFF
--- a/src/system/exceptions.php
+++ b/src/system/exceptions.php
@@ -31,9 +31,10 @@
             if (Phpr::$errorLog !== null) {
                 try {
                     $result = Phpr::$errorLog->logException($this);
-                    
-                    $this->log_id = $result['id'];
-                    $this->log_status = $result['status'];
+                    if ($result) {
+                        $this->log_id = $result['id'];
+                        $this->log_status = $result['status'];
+                    }
                 } catch (Exception $ex) {
                     // Prevent the looping
                 }


### PR DESCRIPTION
[`logException` result can be `false`](https://github.com/damanic/ls1-phproad/blob/master/src/modules/phpr/classes/phpr_errorlog.php#L181) due to disabling the error log or ignoring exceptions which causes the following error:

```
 Phpr_PhpException: Trying to access array offset on value of type bool. In /phproad/system/exceptions.php, line 35 
```